### PR TITLE
Make sure Windows paths are converted.

### DIFF
--- a/backblazeb2.py
+++ b/backblazeb2.py
@@ -233,7 +233,8 @@ class BackBlazeB2(object):
             cur_upload_authorization_token = url['authorizationToken']
 
         # fixup filename
-        filename = re.sub('^/', '', path)
+        filename = re.sub('\\\\', '/', path)    # Make sure Windows paths are converted.
+        filename = re.sub('^/', '', filename)
         filename = re.sub('//', '/', filename)
         # TODO: Figure out URL encoding issue
         filename = unicode(filename, "utf-8")


### PR DESCRIPTION
When on Windows, even if I replace every `\` with `/` in my path, they are saved as `\` when the file is accessed. 

This change converts them right before upload so that we don't get the following error:

```
ERROR: {
  "code": "bad_request",
  "message": "Bad character in percent-encoded string: 92",
  "status": 400
}
```

92 is the ASCII decimal for `\`.