### PR TITLE
Upgrade to More Secure Hash

### DIFF
--- a/backblazeb2/backblazeb2.py
+++ b/backblazeb2/backblazeb2.py
@@ -34,7 +34,10 @@ from Crypto.Cipher import AES
 def derive_key_and_iv(password, salt, key_length, iv_length):
     d = d_i = ''
     while len(d) < key_length + iv_length:
-        d_i = hashlib.md5(d_i + password + salt).digest()
+        d_i = hashlib.sha512(d_i + password + salt).digest()
+        # Extreme Encryption using Key derivation
+        # For more Information: https://docs.python.org/2/library/hashlib.html#hashlib.hashlib.algorithms
+        # d_i = hashlib.pbkdf2_hmac('sha512',password,salt,100000)
         d += d_i
     return d[:key_length], d[key_length:key_length + iv_length]
 


### PR DESCRIPTION
MD5 are not considered reliable anymore. The present approach upgrades The Lib to use SHA512 to Generate Secure Hash and if there is a need for extreme secure measure Enable the comment for "pbkdf2_hmac" and it can even provide security against Brute Force attacks.
More Information here:
About pbkdf2_hmac : https://docs.python.org/2/library/hashlib.html#hashlib.hashlib.algorithms
MD5: https://security.stackexchange.com/questions/19906/is-md5-considered-insecure, https://stackoverflow.com/questions/16713810/how-secure-is-md5-and-sha1